### PR TITLE
Add slides skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# SWE4PY
+*.pdf

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cscs-markdown-slidedeck"]
+	path = cscs-markdown-slidedeck
+	url = https://github.com/kanduri/cscs-markdown-slidedeck

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Software Engineering Practices with Python
+
+This repo contains the slides and exercises for the internal CSCS course with the same name.
+
+## Requirements
+
+- [bash](https://www.gnu.org/software/bash/)
+- An OCI container engine like [podman](https://podman.io/docs/installation) or [docker](https://docs.docker.com/engine/install/)
+
+## Usage
+
+To get slides as pdf...
+
+```
+./build/build.sh
+```
+
+To serve dynamically for local development or presentation...
+
+```
+./run.sh
+```

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This repo contains the slides and exercises for the internal CSCS course with th
 To get slides as pdf...
 
 ```
-./build/build.sh
+./build.sh
 ```
 
 To serve dynamically for local development or presentation...
 
 ```
-./run.sh
+./serve.sh
 ```

--- a/build.sh
+++ b/build.sh
@@ -9,4 +9,4 @@ git submodule update
 command -v docker 2>&1 > /dev/null && { export ocirun="docker"; }
 command -v podman 2>&1 > /dev/null && { export ocirun="podman"; }
 echo "Building pdf using $ocirun..."
-$ocirun run --rm --init -ti --entrypoint node -v $PWD:/home/marp/app/:Z -e LANG=$LANG marpteam/marp-cli:v4.1.2 /home/marp/.cli/marp-cli.js slides.md --pdf
+$ocirun run --rm --init -ti --entrypoint node -v $PWD:/home/marp/app/:Z -e LANG=$LANG marpteam/marp-cli:v4.1.2 /home/marp/.cli/marp-cli.js slides.md --pdf --allow-local-files

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Updating dependencies..."
+git submodule init
+git submodule update
+
+command -v docker 2>&1 > /dev/null && { export ocirun="docker"; }
+command -v podman 2>&1 > /dev/null && { export ocirun="podman"; }
+echo "Building pdf using $ocirun..."
+$ocirun run --rm --init -ti --entrypoint node -v $PWD:/home/marp/app/:Z -e LANG=$LANG marpteam/marp-cli:v4.1.2 /home/marp/.cli/marp-cli.js slides.md --pdf

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+command -v docker 2>&1 > /dev/null && { export ocirun="docker"; }
+command -v podman 2>&1 > /dev/null && { export ocirun="podman"; }
+echo "Serving slides.md using $ocirun..."
+
+$ocirun run -ti --rm --init --entrypoint node -v $PWD:/home/marp/app/:Z -e LANG=$LANG -p 37717:37717 -p 8080:8080 marpteam/marp-cli:v4.1.2 /home/marp/.cli/marp-cli.js -s .

--- a/slides.md
+++ b/slides.md
@@ -70,7 +70,7 @@ Do we know each other?
 
 ---
 
-![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+![bg cover](cscs-markdown-slidedeck/common/title-section-16-9.jpg)
 <!-- _paginate: skip  -->
 <!-- _class: titlesection -->
 <!-- _footer: "" -->
@@ -81,7 +81,7 @@ Do we know each other?
 
 ---
 
-![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+![bg cover](cscs-markdown-slidedeck/common/title-section-16-9.jpg)
 <!-- _paginate: skip  -->
 <!-- _class: titlesection -->
 <!-- _footer: "" -->
@@ -92,7 +92,7 @@ Do we know each other?
 
 ---
 
-![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+![bg cover](cscs-markdown-slidedeck/common/title-section-16-9.jpg)
 <!-- _paginate: skip  -->
 <!-- _class: titlesection -->
 <!-- _footer: "" -->
@@ -103,7 +103,7 @@ Do we know each other?
 
 ---
 
-![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+![bg cover](cscs-markdown-slidedeck/common/title-section-16-9.jpg)
 <!-- _paginate: skip  -->
 <!-- _class: titlesection -->
 <!-- _footer: "" -->
@@ -135,7 +135,7 @@ Do we know each other?
 
 ---
 
-![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+![bg cover](cscs-markdown-slidedeck/common/title-section-16-9.jpg)
 <!-- _paginate: skip  -->
 <!-- _class: titlesection -->
 <!-- _footer: "" -->
@@ -146,7 +146,7 @@ Do we know each other?
 
 ---
 
-![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+![bg cover](cscs-markdown-slidedeck/common/title-section-16-9.jpg)
 <!-- _paginate: skip  -->
 <!-- _class: titlesection -->
 <!-- _footer: "" -->
@@ -157,7 +157,7 @@ Do we know each other?
 
 ---
 
-![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+![bg cover](cscs-markdown-slidedeck/common/title-section-16-9.jpg)
 <!-- _paginate: skip  -->
 <!-- _class: titlesection -->
 <!-- _footer: "" -->
@@ -168,7 +168,7 @@ Do we know each other?
 
 ---
 
-![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+![bg cover](cscs-markdown-slidedeck/common/title-section-16-9.jpg)
 <!-- _paginate: skip  -->
 <!-- _class: titlesection -->
 <!-- _footer: "" -->

--- a/slides.md
+++ b/slides.md
@@ -1,0 +1,194 @@
+---
+marp: true
+theme: cscs
+# class: lead
+paginate: true
+backgroundColor: #fff
+backgroundImage: url('https://marp.app/assets/hero-background.svg')
+footer: '![width:780px](cscs-markdown-slidedeck/common/footer.png)'
+size: 16:9
+---
+
+# Software Engineering Practices with Python
+![bg cover](cscs-markdown-slidedeck/common/title-bg2.png)
+<!-- _paginate: skip  -->
+<!-- _class: titlecover -->
+<!-- _footer: "" -->
+
+### Enrique Gonzalez, Rico Haeuselmann, Tomas Aliaga
+
+#### CSCS internal courses
+
+##### March 10/11 2025
+
+<!-- --- to mark a new slide -->
+---
+
+# Welcome!
+
+:page_facing_up: Course Page: https://confluence.cscs.ch/x/ipWYMw
+
+<!-- TODO: Needs access permissions for attendees (or we put a mirror on CSCS GL) -->
+:computer: Course Repo: https://github.com/eth-cscs/swe4py
+
+:loudspeaker: Local rules and announcements
+
+---
+
+# About this course
+
+Why this course?
+
+Do we know each other?
+
+---
+
+# Participation Survey Highlights
+
+
+
+---
+
+# Agenda Day 1
+
+## March 10th 2025
+
+### Foundational Breadth
+
+<!-- ATTENTION: manual internal links needs numbering bookeeping :( -->
+
+| Time     | Session |
+| -------- | ------- |
+| 09:30    | [Configuring a Python environment (basic)](./slides.md#5) |
+| 10:30    | Coffe Break |
+| 10:45    | [Setting Python common ground](./slides.md#16) |
+| 12:30    | Lunch Break |
+| 13:30    | [Configuring an environment (advanced)](./slides.md#27) |
+| 14:45    | Coffe Break |
+| 15:00    | [Collaboration](./slides.md#38) |
+| 17:00    | EOF |
+
+---
+
+![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+<!-- _paginate: skip  -->
+<!-- _class: titlesection -->
+<!-- _footer: "" -->
+
+# Configuring a Python environment (basic)
+
+[Agenda Day 1](./slides.md#4)
+
+---
+
+![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+<!-- _paginate: skip  -->
+<!-- _class: titlesection -->
+<!-- _footer: "" -->
+
+# Setting Python common ground
+
+[Agenda Day 1](./slides.md#4)
+
+---
+
+![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+<!-- _paginate: skip  -->
+<!-- _class: titlesection -->
+<!-- _footer: "" -->
+
+# Configuring an environment (advanced)
+
+[Agenda Day 1](./slides.md#4)
+
+---
+
+![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+<!-- _paginate: skip  -->
+<!-- _class: titlesection -->
+<!-- _footer: "" -->
+
+# Collaboration
+
+[Agenda Day 1](./slides.md#4)
+
+---
+
+# Agenda Day 2
+
+## March 11th 2025
+
+### Engineering & Collaboration Depth
+
+<!-- ATTENTION: manual internal links needs numbering bookeeping :( -->
+
+| Time     | Session |
+| -------- | ------- |
+| 09:00    | [Testing](./slides.md#49) |
+| 10:45    | Coffe Break |
+| 11:00    | [Pythonic Patterns](./slides.md#60) |
+| 12:30    | Lunch Break |
+| 13:30    | [Advanced Python features](./slides.md#71) |
+| 14:15    | Coffe Break |
+| 14:30    | [Use-cases Break-outs](./slides.md#82) |
+| 16:00    | EOF |
+
+---
+
+![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+<!-- _paginate: skip  -->
+<!-- _class: titlesection -->
+<!-- _footer: "" -->
+
+# Testing
+
+[Agenda Day 2](./slides.md#50)
+
+---
+
+![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+<!-- _paginate: skip  -->
+<!-- _class: titlesection -->
+<!-- _footer: "" -->
+
+# Pythonic Patterns
+
+[Agenda Day 2](./slides.md#50)
+
+---
+
+![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+<!-- _paginate: skip  -->
+<!-- _class: titlesection -->
+<!-- _footer: "" -->
+
+# Advanced Python features
+
+[Agenda Day 2](./slides.md#50)
+
+---
+
+![bg cover](cscs-markdown-slidedeck/common/title-section.jpg)
+<!-- _paginate: skip  -->
+<!-- _class: titlesection -->
+<!-- _footer: "" -->
+
+# Use-cases Break-outs
+
+[Agenda Day 2](./slides.md#50)
+
+
+---
+
+<!-- LAST SLIDE -->
+
+# Thank you all for your participation
+
+![bg cover](cscs-markdown-slidedeck/common/title-bg2.png)
+<!-- _paginate: skip  -->
+<!-- _class: titlecover -->
+<!-- _footer: "" -->
+
+### Software Engineering Practices with Python
+
+#### 2025 internal courses


### PR DESCRIPTION
Proposing slides skeleton.

In our chats I felt an overall preference to having slides with markdown so we can work on the same repo with exercises.

Having been told sometimes not to deviate from original templates, I've tried reusing kanduri's template.

With this approach the default expectation is that all slides live in the same file :/. Let's see if we can work with that to keep it simple, before we split into multiple files and start cross-linking (which is also quite limited and needs manual curation)

PDF building is somewhat broken still, but if you try `./serve` to open `slides.md` it should be good enough?