### PR TITLE
Rico incourse edits

### DIFF
--- a/slides/slides/1.3-environments-installers-building/section-slides.md
+++ b/slides/slides/1.3-environments-installers-building/section-slides.md
@@ -220,21 +220,6 @@ sp --> pkgs["installed packages"]
 sp --> pth[".pth files"]
 ```
 
-```mermaid
-graph TD
-
-.venv/ --> bin/
-.venv/ --> lib/
-
-bin/ --> activate
-bin/ --> python["python -> /path/to/some/bin/python"]
-bin/ --> apps["installed apps"]
-
-lib/ --> sp["pythonX.Y/site-packages/"]
-sp --> pkgs["installed packages"]
-sp --> pth[".pth files"]
-```
-
 ---
 
 ## Anatomy Of A Package Install

--- a/slides/slides/1.4-collaboration/section-slides.md
+++ b/slides/slides/1.4-collaboration/section-slides.md
@@ -137,7 +137,7 @@ layout: fact
 
 ## Let's Fix This
 
-<a href="https://github.com/eth-cscs/swe4py">https://github.com/eth-cscs/swe4py</a>
+<a href="https://github.com/eth-cscs/swe4py">github.com/eth-cscs/swe4py</a>
 
 `exercises/1-4-collaboration/01-dependency-management`
 
@@ -216,7 +216,7 @@ $ uvx run mytool-main --from mytool
 ```
 
 ```bash
-$ uvx run mytool
+$ uvx mytool
 ```
 ````
 
@@ -466,7 +466,7 @@ layout: center
 
 Exercise time:
 
-<a href="https://github.com/eth-cscs/swe4py">https://github.com/eth-cscs/swe4py</a>
+<a href="https://github.com/eth-cscs/swe4py">github.com/eth-cscs/swe4py</a>
 
 `exercises/1-4-collaboration/04-interactivity`
 
@@ -524,8 +524,8 @@ class Foo:
 ### Interactivity: Got It? Keep It!
 
 1. Encode supported interactivity in Jupyter notebooks
-2. Use <a href="https://github.com/treebeardtech/nbmake">https://github.com/treebeardtech/nbmake</a>
-3. Check <a href="https://github.com/GridTools/gt4py">https://github.com/GridTools/gt4py</a> for an example
+2. Use <a href="https://github.com/treebeardtech/nbmake">github.com/treebeardtech/nbmake</a>
+3. Check <a href="https://github.com/GridTools/gt4py">github.com/GridTools/gt4py</a> for an example
 
 
 ---
@@ -582,11 +582,11 @@ Aren't we each defending the choice our IDE made for us anyway?
 
 <v-click>
 
-- Run a formatter (Ruff): <a href="https://docs.astral.sh/ruff/">https://docs.astral.sh/ruff/</a>
+- Run a formatter (Ruff): <a href="https://docs.astral.sh/ruff/">docs.astral.sh/ruff/</a>
 </v-click>
 <v-click>
 
-- On every commit locally (pre-commit): <a href="https://pre-commit.com">https://pre-commit.com</a>
+- On every commit locally (pre-commit): <a href="https://pre-commit.com">pre-commit.com</a>
 </v-click>
 <v-click>
 
@@ -609,11 +609,11 @@ Let your IDEs run wild!
 <br/>
 <v-click>
 
-- Run a linter (Ruff): <a href="https://docs.astral.sh/ruff/">https://docs.astral.sh/ruff/</a>
+- Run a linter (Ruff): <a href="https://docs.astral.sh/ruff/">docs.astral.sh/ruff/</a>
 </v-click>
 <v-click>
 
-- On every commit locally (pre-commit): <a href="https://pre-commit.com">https://pre-commit.com</a>
+- On every commit locally (pre-commit): <a href="https://pre-commit.com">pre-commit.com</a>
 </v-click>
 <v-click>
 

--- a/slides/slides/2.1-testing/section-slides.md
+++ b/slides/slides/2.1-testing/section-slides.md
@@ -903,6 +903,8 @@ layout: end
 
 More about Testing...
 
+**ReFrame**:  https://github.com/reframe-hpc/reframe
+
 **Pandas'** guide: https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#
 
 **Martin Fowler's** posts: https://martinfowler.com/tags/testing.html

--- a/slides/slides/2.2-python-patterns/section-slides.md
+++ b/slides/slides/2.2-python-patterns/section-slides.md
@@ -137,7 +137,7 @@ The structs of the Python world: <a href="https://docs.python.org/3/library/data
 ````md magic-move
 ```python
 class Fruit:
-  __init__(self, fruit_type: str, color: str):
+  def __init__(self, fruit_type: str, color: str):
     self.fruit_type = fruit_type
     self.color = color
     if self.color == "brown" and not self.fruit_type == "coconut":
@@ -224,7 +224,12 @@ class Fruit:
 ---
 
 # Protocols
-
+````md magic-move
+```python
+def render(document: Document, renderer: Renderer):
+	if not isinstance(document, Document):  # optional depending on whether you expect your users to do static type checking in CI or not.
+		raise TypeError("'document' needs to implement the 'Document' protocoll documented here: ...")
+```
 ```python
 from typing import Protocol, runtime_checkable
 
@@ -246,6 +251,7 @@ def render(document: Document, renderer: Renderer):
 	if not isinstance(document, Document):  # optional depending on whether you expect your users to do static type checking in CI or not.
 		raise TypeError("'document' needs to implement the 'Document' protocoll documented here: ...")
 ```
+````
 
 ---
 
@@ -317,3 +323,4 @@ def function(path: str, field_storage: FileStorage, temporary: bool =False) -> B
 
   - Even better: use type hints and let tools (e.g. [Napoleon-sphinx](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html)) to generate the documentation for you
 </v-click>
+````


### PR DESCRIPTION
Minor fixes made during the course.

- fix some link tags so the inner text does not start with `http://` (which is turned into illegal html)
- add reframe to the "More about testing" slide
- remove accidentally duplicated mermaid diagram
- add missing `def`
- add improved iterator type hints